### PR TITLE
UNTRACKED Add Request Option

### DIFF
--- a/example/generated.go
+++ b/example/generated.go
@@ -74,6 +74,7 @@ func getUser(
 	ctx context.Context,
 	client graphql.Client,
 	Login string,
+	opts ...graphql.RequestOption,
 ) (*getUserResponse, error) {
 	req := &graphql.Request{
 		OpName: "getUser",
@@ -98,6 +99,7 @@ query getUser ($Login: String!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err
@@ -106,6 +108,7 @@ query getUser ($Login: String!) {
 func getViewer(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*getViewerResponse, error) {
 	req := &graphql.Request{
 		OpName: "getViewer",
@@ -127,6 +130,7 @@ query getViewer {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/operation.go.tmpl
+++ b/generate/operation.go.tmpl
@@ -12,6 +12,7 @@ func {{.Name}}(
     {{.GraphQLName}} {{.GoType.Reference}},
     {{end -}}
     {{end -}}
+    opts ...{{ref "github.com/Khan/genqlient/graphql.RequestOption"}},
 ) (*{{.ResponseName}}, {{if .Config.Extensions -}}map[string]interface{},{{end}} error) {
     req := &graphql.Request{
         OpName: "{{.Name}}",
@@ -40,6 +41,7 @@ func {{.Name}}(
         {{if ne .Config.ContextType "-"}}ctx{{else}}nil{{end}},
         req,
         resp,
+        opts...,
     )
 	
     return &data, {{if .Config.Extensions -}}resp.Extensions,{{end -}} err

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -1347,6 +1347,7 @@ func (v *ComplexInlineFragmentsRootTopic) GetName() string { return v.Name }
 // interfaces yet.
 func ComplexInlineFragments(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*ComplexInlineFragmentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ComplexInlineFragments",
@@ -1447,6 +1448,7 @@ query ComplexInlineFragments {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -1741,6 +1741,7 @@ func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
 func ComplexNamedFragments(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*ComplexNamedFragmentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ComplexNamedFragments",
@@ -1813,6 +1814,7 @@ fragment MoreVideoFields on Video {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -177,6 +177,7 @@ func (v *__CustomMarshalInput) __premarshalJSON() (*__premarshal__CustomMarshalI
 func CustomMarshal(
 	client graphql.Client,
 	date time.Time,
+	opts ...graphql.RequestOption,
 ) (*CustomMarshalResponse, error) {
 	req := &graphql.Request{
 		OpName: "CustomMarshal",
@@ -201,6 +202,7 @@ query CustomMarshal ($date: Date!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -207,6 +207,7 @@ func CustomMarshalSlice(
 	client graphql.Client,
 	datesss [][][]time.Time,
 	datesssp [][][]*time.Time,
+	opts ...graphql.RequestOption,
 ) (*CustomMarshalSliceResponse, error) {
 	req := &graphql.Request{
 		OpName: "CustomMarshalSlice",
@@ -230,6 +231,7 @@ query CustomMarshalSlice ($datesss: [[[Date!]!]!]!, $datesssp: [[[Date!]!]!]!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
@@ -32,6 +32,7 @@ func convertTimezone(
 	client graphql.Client,
 	dt time.Time,
 	tz string,
+	opts ...graphql.RequestOption,
 ) (*convertTimezoneResponse, error) {
 	req := &graphql.Request{
 		OpName: "convertTimezone",
@@ -54,6 +55,7 @@ query convertTimezone ($dt: DateTime!, $tz: String) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
@@ -22,6 +22,7 @@ func (v *EmptyInterfaceResponse) GetGetComplexJunk() []map[string]*[]*map[string
 
 func EmptyInterface(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*EmptyInterfaceResponse, error) {
 	req := &graphql.Request{
 		OpName: "EmptyInterface",
@@ -41,6 +42,7 @@ query EmptyInterface {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -268,6 +268,7 @@ func (v *VideoFieldsParentTopic) GetVideoChildren() []ChildVideoFields { return 
 
 func ComplexNamedFragments(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*InnerQueryFragment, error) {
 	req := &graphql.Request{
 		OpName: "ComplexNamedFragments",
@@ -317,6 +318,7 @@ fragment ChildVideoFields on Video {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
@@ -57,6 +57,7 @@ func (v *__InputEnumQueryInput) GetRole() Role { return v.Role }
 func InputEnumQuery(
 	client graphql.Client,
 	role Role,
+	opts ...graphql.RequestOption,
 ) (*InputEnumQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InputEnumQuery",
@@ -80,6 +81,7 @@ query InputEnumQuery ($role: Role!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -180,6 +180,7 @@ func (v *__InputObjectQueryInput) GetQuery() UserQueryInput { return v.Query }
 func InputObjectQuery(
 	client graphql.Client,
 	query UserQueryInput,
+	opts ...graphql.RequestOption,
 ) (*InputObjectQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InputObjectQuery",
@@ -203,6 +204,7 @@ query InputObjectQuery ($query: UserQueryInput) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -522,6 +522,7 @@ func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() string { ret
 
 func InterfaceListField(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*InterfaceListFieldResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceListField",
@@ -557,6 +558,7 @@ query InterfaceListField {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -508,6 +508,7 @@ func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() *string { re
 
 func InterfaceListOfListOfListsField(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*InterfaceListOfListOfListsFieldResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceListOfListOfListsField",
@@ -535,6 +536,7 @@ query InterfaceListOfListOfListsField {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -506,6 +506,7 @@ func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() InterfaceNestingRoo
 
 func InterfaceNesting(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*InterfaceNestingResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceNesting",
@@ -537,6 +538,7 @@ query InterfaceNesting {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -628,6 +628,7 @@ func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() *string { return v
 
 func InterfaceNoFragmentsQuery(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*InterfaceNoFragmentsQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceNoFragmentsQuery",
@@ -664,6 +665,7 @@ query InterfaceNoFragmentsQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
@@ -44,6 +44,7 @@ func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
 func ListInputQuery(
 	client graphql.Client,
 	names []string,
+	opts ...graphql.RequestOption,
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
@@ -67,6 +68,7 @@ query ListInputQuery ($names: [String]) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
@@ -18,6 +18,7 @@ func (v *ListOfListsOfListsResponse) GetListOfListsOfLists() [][][]string {
 
 func ListOfListsOfLists(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*ListOfListsOfListsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListOfListsOfLists",
@@ -36,6 +37,7 @@ query ListOfListsOfLists {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -329,6 +329,7 @@ func MultipleDirectives(
 	client graphql.Client,
 	query MyInput,
 	queries []*UserQueryInput,
+	opts ...graphql.RequestOption,
 ) (*MyMultipleDirectivesResponse, error) {
 	req := &graphql.Request{
 		OpName: "MultipleDirectives",
@@ -356,6 +357,7 @@ query MultipleDirectives ($query: UserQueryInput, $queries: [UserQueryInput]) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -226,6 +226,7 @@ func OmitEmptyQuery(
 	dt time.Time,
 	tz string,
 	tzNoOmitEmpty string,
+	opts ...graphql.RequestOption,
 ) (*OmitEmptyQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "OmitEmptyQuery",
@@ -258,6 +259,7 @@ query OmitEmptyQuery ($query: UserQueryInput, $queries: [UserQueryInput], $dt: D
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -235,6 +235,7 @@ func PointersQuery(
 	query *UserQueryInput,
 	dt time.Time,
 	tz *string,
+	opts ...graphql.RequestOption,
 ) (*PointersQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "PointersQuery",
@@ -268,6 +269,7 @@ query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -232,6 +232,7 @@ func PointersQuery(
 	query *UserQueryInput,
 	dt *time.Time,
 	tz string,
+	opts ...graphql.RequestOption,
 ) (*PointersQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "PointersQuery",
@@ -265,6 +266,7 @@ query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
@@ -74,6 +74,7 @@ func (v *__GetPokemonSiblingsInput) GetInput() testutil.Pokemon { return v.Input
 func GetPokemonSiblings(
 	client graphql.Client,
 	input testutil.Pokemon,
+	opts ...graphql.RequestOption,
 ) (*GetPokemonSiblingsResponse, error) {
 	req := &graphql.Request{
 		OpName: "GetPokemonSiblings",
@@ -107,6 +108,7 @@ query GetPokemonSiblings ($input: PokemonInput!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
@@ -42,6 +42,7 @@ func (v *QueryWithAliasUser) GetOtherID() testutil.ID { return v.OtherID }
 
 func QueryWithAlias(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithAliasResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithAlias",
@@ -63,6 +64,7 @@ query QueryWithAlias {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
@@ -42,6 +42,7 @@ func (v *QueryWithDoubleAliasUser) GetAlsoID() testutil.ID { return v.AlsoID }
 
 func QueryWithDoubleAlias(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithDoubleAliasResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithDoubleAlias",
@@ -63,6 +64,7 @@ query QueryWithDoubleAlias {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
@@ -64,6 +64,7 @@ const (
 
 func QueryWithEnums(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithEnumsResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithEnums",
@@ -87,6 +88,7 @@ query QueryWithEnums {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
@@ -43,6 +43,7 @@ func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []string { return v.Ema
 
 func QueryWithSlices(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithSlicesResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithSlices",
@@ -66,6 +67,7 @@ query QueryWithSlices {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
@@ -45,6 +45,7 @@ func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() string { return v
 
 func QueryWithStructs(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithStructsResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithStructs",
@@ -68,6 +69,7 @@ query QueryWithStructs {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
@@ -71,6 +71,7 @@ func (v *__RecursionInput) GetInput() RecursiveInput { return v.Input }
 func Recursion(
 	client graphql.Client,
 	input RecursiveInput,
+	opts ...graphql.RequestOption,
 ) (*RecursionResponse, error) {
 	req := &graphql.Request{
 		OpName: "Recursion",
@@ -100,6 +101,7 @@ query Recursion ($input: RecursiveInput!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -241,6 +241,7 @@ func (v *SimpleInlineFragmentResponse) __premarshalJSON() (*__premarshalSimpleIn
 
 func SimpleInlineFragment(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleInlineFragmentResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleInlineFragment",
@@ -269,6 +270,7 @@ query SimpleInlineFragment {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
@@ -44,6 +44,7 @@ func (v *__SimpleInputQueryInput) GetName() string { return v.Name }
 func SimpleInputQuery(
 	client graphql.Client,
 	name string,
+	opts ...graphql.RequestOption,
 ) (*SimpleInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleInputQuery",
@@ -67,6 +68,7 @@ query SimpleInputQuery ($name: String!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
@@ -48,6 +48,7 @@ func (v *__SimpleMutationInput) GetName() string { return v.Name }
 func SimpleMutation(
 	client graphql.Client,
 	name string,
+	opts ...graphql.RequestOption,
 ) (*SimpleMutationResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleMutation",
@@ -72,6 +73,7 @@ mutation SimpleMutation ($name: String!) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -548,6 +548,7 @@ func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
 func SimpleNamedFragment(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleNamedFragmentResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleNamedFragment",
@@ -584,6 +585,7 @@ fragment VideoFields on Video {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
@@ -35,6 +35,7 @@ func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
 
 func SimpleQuery(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -55,6 +56,7 @@ query SimpleQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -426,6 +426,7 @@ func (v *VideoFields) GetDuration() int { return v.Duration }
 
 func StructOption(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*StructOptionResponse, error) {
 	req := &graphql.Request{
 		OpName: "StructOption",
@@ -468,6 +469,7 @@ fragment VideoFields on Video {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
@@ -39,6 +39,7 @@ func (v *TypeNameQueryUser) GetId() testutil.ID { return v.Id }
 
 func TypeNameQuery(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*TypeNameQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "TypeNameQuery",
@@ -60,6 +61,7 @@ query TypeNameQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -266,6 +266,7 @@ func (v *User) GetName() string { return v.Name }
 
 func TypeNames(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*Resp, error) {
 	req := &graphql.Request{
 		OpName: "TypeNames",
@@ -296,6 +297,7 @@ query TypeNames {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -176,6 +176,7 @@ func (v *UnionNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalUnionNo
 
 func UnionNoFragmentsQuery(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*UnionNoFragmentsQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "UnionNoFragmentsQuery",
@@ -196,6 +197,7 @@ query UnionNoFragmentsQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
@@ -64,6 +64,7 @@ func (v *UsesEnumTwiceQueryResponse) GetOtherUser() UsesEnumTwiceQueryOtherUser 
 
 func UsesEnumTwiceQuery(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*UsesEnumTwiceQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "UsesEnumTwiceQuery",
@@ -87,6 +88,7 @@ query UsesEnumTwiceQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -180,6 +180,7 @@ func (v *unexportedUser) GetId() testutil.ID { return v.Id }
 func unexported(
 	client graphql.Client,
 	query UserQueryInput,
+	opts ...graphql.RequestOption,
 ) (*unexportedResponse, error) {
 	req := &graphql.Request{
 		OpName: "unexported",
@@ -203,6 +204,7 @@ query unexported ($query: UserQueryInput) {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -63,6 +64,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
@@ -40,6 +40,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx testutil.MyContext,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -66,6 +67,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
@@ -33,7 +33,9 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
-func SimpleQuery() (*SimpleQueryResponse, error) {
+func SimpleQuery(
+	opts ...graphql.RequestOption,
+) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
 		Query: `
@@ -59,6 +61,7 @@ query SimpleQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
@@ -41,6 +41,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx testutil.MyContext,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -61,6 +62,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
@@ -34,6 +34,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -54,6 +55,7 @@ query SimpleQuery {
 		nil,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
@@ -81,6 +81,7 @@ func ListInputQuery(
 	ctx context.Context,
 	client graphql.Client,
 	names []*string,
+	opts ...graphql.RequestOption,
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
@@ -104,6 +105,7 @@ query ListInputQuery ($names: [String]) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err
@@ -112,6 +114,7 @@ query ListInputQuery ($names: [String]) {
 func QueryWithSlices(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithSlicesResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithSlices",
@@ -135,6 +138,7 @@ query QueryWithSlices {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
@@ -81,6 +81,7 @@ func ListInputQuery(
 	ctx context.Context,
 	client graphql.Client,
 	names []string,
+	opts ...graphql.RequestOption,
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
@@ -104,6 +105,7 @@ query ListInputQuery ($names: [String]) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err
@@ -112,6 +114,7 @@ query ListInputQuery ($names: [String]) {
 func QueryWithSlices(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*QueryWithSlicesResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithSlices",
@@ -135,6 +138,7 @@ query QueryWithSlices {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated-structrefs.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated-structrefs.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
@@ -37,6 +37,7 @@ func (v *SimpleQueryUser) GetId() string { return v.Id }
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
@@ -57,6 +58,7 @@ query SimpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, err

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Khan/genqlient
+module github.com/nbcnews/genqlient
 
 go 1.16
 

--- a/graphql/client.go
+++ b/graphql/client.go
@@ -14,6 +14,9 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+// RequestOption is a function that can be passed to MakeRequest to modify the http request behavior.
+type RequestOption func(req *http.Request)
+
 // Client is the interface that the generated code calls into to actually make
 // requests.
 type Client interface {
@@ -37,6 +40,7 @@ type Client interface {
 		ctx context.Context,
 		req *Request,
 		resp *Response,
+		opts ...RequestOption,
 	) error
 }
 
@@ -122,7 +126,7 @@ type Response struct {
 	Errors     gqlerror.List          `json:"errors,omitempty"`
 }
 
-func (c *client) MakeRequest(ctx context.Context, req *Request, resp *Response) error {
+func (c *client) MakeRequest(ctx context.Context, req *Request, resp *Response, opts ...RequestOption) error {
 	var httpReq *http.Request
 	var err error
 	if c.method == http.MethodGet {
@@ -135,6 +139,9 @@ func (c *client) MakeRequest(ctx context.Context, req *Request, resp *Response) 
 		return err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	for _, opt := range opts {
+		opt(httpReq)
+	}
 
 	if ctx != nil {
 		httpReq = httpReq.WithContext(ctx)

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -3082,6 +3082,7 @@ func createUser(
 	ctx context.Context,
 	client graphql.Client,
 	user NewUser,
+	opts ...graphql.RequestOption,
 ) (*createUserResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "createUser",
@@ -3106,6 +3107,7 @@ mutation createUser ($user: NewUser!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3114,6 +3116,7 @@ mutation createUser ($user: NewUser!) {
 func failingQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*failingQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "failingQuery",
@@ -3135,6 +3138,7 @@ query failingQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3144,6 +3148,7 @@ func queryWithCustomMarshal(
 	ctx context.Context,
 	client graphql.Client,
 	date time.Time,
+	opts ...graphql.RequestOption,
 ) (*queryWithCustomMarshalResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshal",
@@ -3169,6 +3174,7 @@ query queryWithCustomMarshal ($date: Date!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3179,6 +3185,7 @@ func queryWithCustomMarshalOptional(
 	client graphql.Client,
 	date *time.Time,
 	id *string,
+	opts ...graphql.RequestOption,
 ) (*queryWithCustomMarshalOptionalResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshalOptional",
@@ -3205,6 +3212,7 @@ query queryWithCustomMarshalOptional ($date: Date, $id: ID) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3214,6 +3222,7 @@ func queryWithCustomMarshalSlice(
 	ctx context.Context,
 	client graphql.Client,
 	dates []time.Time,
+	opts ...graphql.RequestOption,
 ) (*queryWithCustomMarshalSliceResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshalSlice",
@@ -3239,6 +3248,7 @@ query queryWithCustomMarshalSlice ($dates: [Date!]!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3248,6 +3258,7 @@ func queryWithFlatten(
 	ctx context.Context,
 	client graphql.Client,
 	ids []string,
+	opts ...graphql.RequestOption,
 ) (*QueryFragment, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithFlatten",
@@ -3307,6 +3318,7 @@ fragment FriendsFields on User {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3316,6 +3328,7 @@ func queryWithFragments(
 	ctx context.Context,
 	client graphql.Client,
 	ids []string,
+	opts ...graphql.RequestOption,
 ) (*queryWithFragmentsResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithFragments",
@@ -3369,6 +3382,7 @@ query queryWithFragments ($ids: [ID!]!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3378,6 +3392,7 @@ func queryWithInterfaceListField(
 	ctx context.Context,
 	client graphql.Client,
 	ids []string,
+	opts ...graphql.RequestOption,
 ) (*queryWithInterfaceListFieldResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithInterfaceListField",
@@ -3403,6 +3418,7 @@ query queryWithInterfaceListField ($ids: [ID!]!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3412,6 +3428,7 @@ func queryWithInterfaceListPointerField(
 	ctx context.Context,
 	client graphql.Client,
 	ids []string,
+	opts ...graphql.RequestOption,
 ) (*queryWithInterfaceListPointerFieldResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithInterfaceListPointerField",
@@ -3437,6 +3454,7 @@ query queryWithInterfaceListPointerField ($ids: [ID!]!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3446,6 +3464,7 @@ func queryWithInterfaceNoFragments(
 	ctx context.Context,
 	client graphql.Client,
 	id string,
+	opts ...graphql.RequestOption,
 ) (*queryWithInterfaceNoFragmentsResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithInterfaceNoFragments",
@@ -3475,6 +3494,7 @@ query queryWithInterfaceNoFragments ($id: ID!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3484,6 +3504,7 @@ func queryWithNamedFragments(
 	ctx context.Context,
 	client graphql.Client,
 	ids []string,
+	opts ...graphql.RequestOption,
 ) (*queryWithNamedFragmentsResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithNamedFragments",
@@ -3537,6 +3558,7 @@ fragment MoreUserFields on User {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3546,6 +3568,7 @@ func queryWithOmitempty(
 	ctx context.Context,
 	client graphql.Client,
 	id string,
+	opts ...graphql.RequestOption,
 ) (*queryWithOmitemptyResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithOmitempty",
@@ -3571,6 +3594,7 @@ query queryWithOmitempty ($id: ID) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3580,6 +3604,7 @@ func queryWithVariables(
 	ctx context.Context,
 	client graphql.Client,
 	id string,
+	opts ...graphql.RequestOption,
 ) (*queryWithVariablesResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithVariables",
@@ -3605,6 +3630,7 @@ query queryWithVariables ($id: ID!) {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3613,6 +3639,7 @@ query queryWithVariables ($id: ID!) {
 func simpleQuery(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*simpleQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "simpleQuery",
@@ -3635,6 +3662,7 @@ query simpleQuery {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err
@@ -3643,6 +3671,7 @@ query simpleQuery {
 func simpleQueryExt(
 	ctx context.Context,
 	client graphql.Client,
+	opts ...graphql.RequestOption,
 ) (*simpleQueryExtResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "simpleQueryExt",
@@ -3665,6 +3694,7 @@ query simpleQueryExt {
 		ctx,
 		req,
 		resp,
+		opts...,
 	)
 
 	return &data, resp.Extensions, err

--- a/internal/integration/roundtrip.go
+++ b/internal/integration/roundtrip.go
@@ -88,7 +88,7 @@ func (c *roundtripClient) roundtripResponse(resp interface{}) {
 	assert.Equal(c.t, string(body), string(bodyAgain))
 }
 
-func (c *roundtripClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {
+func (c *roundtripClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response, opts ...graphql.RequestOption) error {
 	// TODO(benkraft): Also check the variables round-trip.  This is a bit less
 	// important since most of the code is the same (and input types are
 	// strictly simpler), and a bit hard to do because when asserting about


### PR DESCRIPTION

Add request option to operational template and graphql client.

```Go
type RequestOption func(req *http.Request)
```

That should allow the client to modify each request behavior by implementing and passing the `RequestOption` func as the variadic args.  Here is the one example that passes the `x-request-id` to graphql server. 

```Go
func WithRequestID(id string) graphql.RequestOption {
	return func(req *http.Request) {
		req.Header.Set("x-request-id", id)
	}
}
```

As this is the variadic args (optional), that won't impact any existing func that existing client created.